### PR TITLE
Normalizes unpunctuated Vancouver-style names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ rvm:
   - 2.0.0
   - 1.9.3
   - rbx-2
++before_install:
+  - gem install bundler
 notifications:
   email:
     - sylvester@keil.or.at

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.0.0
   - 1.9.3
   - rbx-2
-+before_install:
+before_install:
   - gem install bundler
 notifications:
   email:

--- a/lib/anystyle/parser/normalizer.rb
+++ b/lib/anystyle/parser/normalizer.rb
@@ -180,6 +180,10 @@ module Anystyle
         names.gsub!(/\s*(\.\.\.|…)\s*/, '')
         names.gsub!(/;|:/, ',')
 
+        # Add surname/initial punctuation separator for Vancouver-style names
+        # E.g. Rang HP, Dale MM, Ritter JM, Moore PK
+        names.gsub!(/\b(\p{Lu}[^\s,.]+)\s+([\p{Lu}][\p{Lu}\-]{0,3})(,|$)/, '\1, \2\3')
+
         Namae.parse!(names).map { |name|
           name.normalize_initials
           name.sort_order

--- a/spec/anystyle/parser/normalizer_spec.rb
+++ b/spec/anystyle/parser/normalizer_spec.rb
@@ -52,6 +52,7 @@ module Anystyle
           ['Doe, J', 'Doe, J.'],
           ['JE Doe', 'Doe, J.E.'],
           ['Doe, JE', 'Doe, J.E.'],
+          ['Dendle MT, Sacchettini JC, Kelly JW', 'Dendle, M.T. and Sacchettini, J.C. and Kelly, J.W.'],
           ['Edgar A. Poe, Herman Melville', 'Poe, Edgar A. and Melville, Herman'],
           ['Edgar A. Poe; Herman Melville', 'Poe, Edgar A. and Melville, Herman'],
           ['Poe, Edgar A., Melville, Herman', 'Poe, Edgar A. and Melville, Herman'],


### PR DESCRIPTION
* Adds punctuation separator between family name and initials for Vancouver-style author names
* Example: `Rang HP, Dale MM, Ritter JM, Moore PK` normalizes to `Rang, HP, Dale, MM, Ritter, JM, Moore, PK` so that these can be parsed correctly into family name/given name pairs

NB. Alternative is to normalize them by switching the order of surname-initials to initials-surname