### PR TITLE
No extra comma normalizing Surname, Given Initial

### DIFF
--- a/lib/anystyle/parser/normalizer.rb
+++ b/lib/anystyle/parser/normalizer.rb
@@ -183,6 +183,8 @@ module Anystyle
         # Add surname/initial punctuation separator for Vancouver-style names
         # E.g. Rang HP, Dale MM, Ritter JM, Moore PK
         names.gsub!(/\b(\p{Lu}[^\s,.]+)\s+([\p{Lu}][\p{Lu}\-]{0,3})(,|$)/, '\1, \2\3')
+        # Remove the additional comma when we incorrectly generated one for Surname, Given, Initial
+        names.gsub!(/(\p{Ll}[^\s,]+),\s+(\p{Lu}\p{Ll}[^\s,]*),\s+([\p{Lu}][\p{Lu}\-]{0,3})(,|$)/, '\1, \2 \3\4')
 
         Namae.parse!(names).map { |name|
           name.normalize_initials

--- a/spec/anystyle/parser/normalizer_spec.rb
+++ b/spec/anystyle/parser/normalizer_spec.rb
@@ -47,6 +47,8 @@ module Anystyle
 
         [
           ['Poe, Edgar A.', 'Poe, Edgar A.'],
+          ['Poe, Edgar A', 'Poe, Edgar A.'],
+          ['Kates, Robert W', 'Kates, Robert W.'],
           ['Edgar A. Poe', 'Poe, Edgar A.'],
           ['J Doe', 'Doe, J.'],
           ['Doe, J', 'Doe, J.'],


### PR DESCRIPTION
* Removes unwanted extra comma introduced by Vancouver name normalization
when name is `Surname, Given Initial`
* Adds additional unit tests to confirm