### PR TITLE
French abbreviations

### DIFF
--- a/lib/anystyle/parser/normalizer.rb
+++ b/lib/anystyle/parser/normalizer.rb
@@ -138,7 +138,7 @@ module Anystyle
       end
 
       def strip_et_al(names)
-        !!names.sub!(/(\bet\s+(al|coll\.)\b|\bu\.\s*a\.|(\band|\&)\s+others).*$/, '')
+        !!names.sub!(/(\bet\s+(al|coll)\b|\bu\.\s*a\.|(\band|\&)\s+others).*$/, '')
       end
 
       def normalize_translator(hash)

--- a/lib/anystyle/parser/normalizer.rb
+++ b/lib/anystyle/parser/normalizer.rb
@@ -138,7 +138,7 @@ module Anystyle
       end
 
       def strip_et_al(names)
-        !!names.sub!(/(\bet\s+al\b|\bu\.\s*a\.|(\band|\&)\s+others).*$/, '')
+        !!names.sub!(/(\bet\s+(al|coll\.)\b|\bu\.\s*a\.|(\band|\&)\s+others).*$/, '')
       end
 
       def normalize_translator(hash)
@@ -148,6 +148,7 @@ module Anystyle
         translators.gsub!(/^\W+|\W+$/, '')
         translators.gsub!(/[^[:alpha:]]*\btrans(l(ated)?)?\b[^[:alpha:]]*/i, '')
         translators.gsub!(/\bby\b/i, '')
+        translators.gsub!(/\btrad\.\b/i, '')
 
         hash[:translator] = normalize_names(translators)
         hash

--- a/spec/anystyle/parser/normalizer_spec.rb
+++ b/spec/anystyle/parser/normalizer_spec.rb
@@ -125,6 +125,7 @@ module Anystyle
           expect(n.normalize_editor(:editor => 'Edward Wood u. a.')[:editor]).to eq('Wood, Edward')
           expect(n.normalize_editor(:editor => 'Edward Wood and others')[:editor]).to eq('Wood, Edward')
           expect(n.normalize_editor(:editor => 'Edward Wood & others')[:editor]).to eq('Wood, Edward')
+          expect(n.normalize_editor(:editor => 'Edward Wood et coll.')[:editor]).to eq('Wood, Edward')
         end
       end
 
@@ -138,6 +139,8 @@ module Anystyle
           expect(n.normalize_translator(:translator => 'übers. v. J Doe')).to eq({ :translator => 'Doe, J.' })
           expect(n.normalize_translator(:translator => 'Übersetzung v. J Doe')).to eq({ :translator => 'Doe, J.' })
           expect(n.normalize_translator(:translator => 'In der Übersetzung von J Doe')).to eq({ :translator => 'Doe, J.' })
+          expect(n.normalize_translator(:translator => 'Trad. J Doe')).to eq({ :translator => 'Doe, J.' })
+          expect(n.normalize_translator(:translator => 'trad. J Doe')).to eq({ :translator => 'Doe, J.' })
         end
       end
 


### PR DESCRIPTION
Add French abbreviations "et coll." and "Trad." to the normaliser