### PR TITLE
Dictionary fixes

### DIFF
--- a/lib/anystyle/parser/dictionary.rb
+++ b/lib/anystyle/parser/dictionary.rb
@@ -197,7 +197,7 @@ module Anystyle
       def populate
         require 'zlib'
 
-        File.open(options[:source], 'r:UTF-8') do |f|
+        File.open(options[:source], 'rb:UTF-8') do |f|
           mode = 0
 
           Zlib::GzipReader.new(f).each do |line|

--- a/lib/anystyle/parser/dictionary.rb
+++ b/lib/anystyle/parser/dictionary.rb
@@ -197,12 +197,10 @@ module Anystyle
       def populate
         require 'zlib'
 
-        File.open(options[:source], 'rb:UTF-8') do |f|
+        File.open(options[:source], 'rb') do |f|
           mode = 0
-
-          Zlib::GzipReader.new(f).each do |line|
+          Zlib::GzipReader.new(f, encoding: "UTF-8").each do |line|
             line.strip!
-
             if line.start_with?('#')
               case line
               when /^## male/i


### PR DESCRIPTION
Small fixes for opening the dictionary file:
1. "b" flag is required when opening gzip files on Windows
2. The "UTF-8" flag is redundant / misleading when opening the gzip file
3. The "UTF-8" flag is necessary, however, on the gzip reader stream

Without (3), accented characters in place/person names are not correctly matched. A test case: "Weber, M., 1922. Wirtschaft und Gesellschaft: Grundriss der verstehenden Soziologie. JCB Mohr, Tübingen." On Anycite.io, Tübingen is not recognised as a place, even though it is in the dictionary. This fixes that.